### PR TITLE
邮箱号和密码正则匹配改成dify新版本的

### DIFF
--- a/admin/server/api/v1/system/sys_user.go
+++ b/admin/server/api/v1/system/sys_user.go
@@ -149,7 +149,7 @@ func (b *BaseApi) Register(c *gin.Context) {
 		return
 	}
 	if err = gaia.IsUserPasswordValid(r.Password); err != nil {
-		response.FailWithMessage("请使用6-32位最少包含一个字母数字组合的密码", c)
+		response.FailWithMessage(err.Error(), c)
 		return
 	}
 	// Extend: Start admin init
@@ -194,7 +194,7 @@ func (b *BaseApi) ChangePassword(c *gin.Context) {
 	}
 	uid := utils.GetUserID(c)
 	if err = gaia.IsUserPasswordValid(req.Password); err != nil {
-		response.FailWithMessage("请使用6-32位最少包含一个字母数字组合的密码", c)
+		response.FailWithMessage(err.Error(), c)
 		return
 	}
 	u := &system.SysUser{GVA_MODEL: global.GVA_MODEL{ID: uid}, Password: req.Password}
@@ -489,7 +489,7 @@ func (b *BaseApi) ResetPassword(c *gin.Context) {
 		return
 	}
 	if err = gaia.IsUserPasswordValid(user.Password); err != nil {
-		response.FailWithMessage("请使用6-32位最少包含一个字母数字组合的密码", c)
+		response.FailWithMessage(err.Error(), c)
 		return
 	}
 	err = userService.ResetPassword(user.ID, user.Password)

--- a/admin/server/service/gaia/account.go
+++ b/admin/server/service/gaia/account.go
@@ -24,16 +24,8 @@ import (
 // @return info request.GetUserInfoByUserName, err error
 func IsUserPasswordValid(passwd string) (err error) {
 	var matched bool
-	if matched, err = regexp.MatchString("^[A-Za-z0-9]{6,32}$", passwd); err != nil || !matched {
-		return errors.New("请使用6-32位最少包含一个字母数字组合的密码")
-	}
-	if matched, err = regexp.MatchString("[A-Za-z]", passwd); err != nil || !matched {
-		err = errors.New("请使用6-32位最少包含一个字母数字组合的密码")
-		return
-	}
-	if matched, err = regexp.MatchString("[0-9]", passwd); err != nil || !matched {
-		err = errors.New("请使用6-32位最少包含一个字母数字组合的密码")
-		return
+	if matched, err = regexp.MatchString("^(?=.*[a-zA-Z])(?=.*\\d).{8,}$", passwd); err != nil || !matched {
+		return errors.New("请使用最少8位且最少有一个字母数字组合的密码")
 	}
 	return nil
 }

--- a/admin/server/service/gaia/account.go
+++ b/admin/server/service/gaia/account.go
@@ -23,10 +23,21 @@ import (
 // @param: passwd
 // @return info request.GetUserInfoByUserName, err error
 func IsUserPasswordValid(passwd string) (err error) {
-	var matched bool
-	if matched, err = regexp.MatchString("^(?=.*[a-zA-Z])(?=.*\\d).{8,}$", passwd); err != nil || !matched {
+	// Check if the string is at least 8 characters long
+	if len(passwd) < 8 {
 		return errors.New("请使用最少8位且最少有一个字母数字组合的密码")
 	}
+
+	// Check if the string contains at least one letter
+	if containsLetter := regexp.MustCompile(`[a-zA-Z]`).MatchString(passwd); !containsLetter {
+		return errors.New("请最少最少有一个字母组合的密码")
+	}
+
+	// Check if the string contains at least one digit
+	if containsLetter := regexp.MustCompile(`\d`).MatchString(passwd); !containsLetter {
+		return errors.New("请最少最少有一个数字组合的密码")
+	}
+
 	return nil
 }
 

--- a/admin/web/src/view/superAdmin/user/user.vue
+++ b/admin/web/src/view/superAdmin/user/user.vue
@@ -455,7 +455,7 @@ const rules = ref({
     { pattern: /^1([38][0-9]|4[014-9]|[59][0-35-9]|6[2567]|7[0-8])\d{8}$/, message: '请输入合法手机号', trigger: 'blur' },
   ],
   email: [
-    { pattern: /^([0-9A-Za-z\-_.]+)@([0-9a-z]+\.[a-z]{2,3}(\.[a-z]{2})?)$/g, message: '请输入正确的邮箱', trigger: 'blur' },
+    { pattern: /^[\w\.!#$%&'*+\-/=?^_`{|}~]+@([\w-]+\.)+[\w-]{2,}$/g, message: '请输入正确的邮箱', trigger: 'blur' },
   ],
   authorityId: [
     { required: true, message: '请选择用户角色', trigger: 'blur' }

--- a/admin/web/src/view/user/index.vue
+++ b/admin/web/src/view/user/index.vue
@@ -418,8 +418,8 @@ const resetPasswordFunc = (row) => {
   ElMessageBox.prompt(`是否修改 ${row.nickName} 密码`, '请注意', {
     confirmButtonText: '修改',
     cancelButtonText: '取消',
-    inputPattern: /^[0-9a-zA-Z\\!@#$]{6,26}$/,
-    inputErrorMessage: '设置6~26个字的密码，组成字符为0-9a-zA-Z!@#$',
+    inputPattern: /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/,
+    inputErrorMessage: '设置8~26个字的密码，至少包含一个英文一个数字',
   }).then(async ({value}) => {
     const res = await resetPassword({
       Password: value.trim(),
@@ -494,7 +494,7 @@ const rules = ref({
   ],
   email: [
     { required: true, message: '请输入用户邮箱', trigger: 'blur' },
-    { pattern: /^([0-9A-Za-z\-_.]+)@([0-9a-z]+\.[a-z]{2,3}(\.[a-z]{2})?)$/g, message: '请输入正确的邮箱', trigger: 'blur' },
+    { pattern: /^[\w\.!#$%&'*+\-/=?^_`{|}~]+@([\w-]+\.)+[\w-]{2,}$/g, message: '请输入正确的邮箱', trigger: 'blur' },
   ],
   authorityId: [
     { required: true, message: '请选择用户角色', trigger: 'blur' }


### PR DESCRIPTION
URL https://github.com/YFGaia/dify-plus/issues/16

# Summary

Password and email regular expressions do not work with dify.
Currently, the dify password regular expression has been changed to /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/
Email regular expression /^[\w\.!#$%&'*+\-/=?^_`{|}~]+@([\w-]+\.)+[\w-]{2,}$/
The dify login interface, registration interface, backend login, user creation and password modification interface, and related APIs have all been checked and modified

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

